### PR TITLE
fix plugin trashing existing .npmrc

### DIFF
--- a/bin/npm-auth
+++ b/bin/npm-auth
@@ -47,6 +47,6 @@ if [ ! -e ~/.npmrc ]; then
     echo "-- Error logging into NPM"
     exit 1
 else
-    echo $(cat ~/.npmrc) | sed 's/[[:blank:]]\+/\n/g' > $path.npmrc
+    cat ~/.npmrc >> $path.npmrc
     echo "-- NPM authentication done!"
 fi


### PR DESCRIPTION
The fix is to append the contents of ~/.npmrc to the local .npmrc rather than overwrite it.

Also, this fixes an issue where only the first line would be appended (`always-auth` etc was getting lost). This was caused by echo only printing to the first carriage return. I've also stopped replacing whitespace with newlines as it seems error prone.