### PR TITLE
Adding newline to ensure added token works

### DIFF
--- a/bin/npm-auth
+++ b/bin/npm-auth
@@ -47,6 +47,7 @@ if [ ! -e ~/.npmrc ]; then
     echo "-- Error logging into NPM"
     exit 1
 else
+    printf "\n" >> $path.npmrc
     cat ~/.npmrc >> $path.npmrc
     echo "-- NPM authentication done!"
 fi


### PR DESCRIPTION
If a `.npmrc` file has no new line at the end then a user will get the token appended to another property causing the auth to say it succeeded, but as soon as something needs it is called it breaks.

This simple inserts a new line (worst case they get an extra blank line) between any current settings and the token.