### PR TITLE
Adding scope line for token login

### DIFF
--- a/bin/npm-auth
+++ b/bin/npm-auth
@@ -37,7 +37,11 @@ if [ -z "$token" ]; then
 
     expect-npm-auth "npm login --registry $registry $scope_option" $username $password $email >/dev/null 2>&1
 else
-    echo "//$registry/:_authToken=$token" > ~/.npmrc
+    echo "//${registry//http[s]*:\/\//}/:_authToken=$token" > ~/.npmrc
+
+    if [ -n "$scope" ]; then
+        echo "$scope:registry=$registry" >> ~/.npmrc
+    fi
 fi
 
 endtime=$(date +%s.%N)


### PR DESCRIPTION
Appends a line to the `.npmrc` to point the scope to the particular registry e.g.
Trims off http or https for the authline.
    
```
@myscpope:registry=https://npm.myregistry.com
```
